### PR TITLE
Use DBLP SPARQL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Google Scholar is great at collecting publications but **terrible at showing th
 
 This extension uses historical **CORE Conference Rankings** from the years **2023, 2021, 2020, 2018, 2017, and 2014**, courtesy of [**Australasian Computing Research and Education (CORE)**](https://www.linkedin.com/company/australasian-computing-research-and-education-core/). Please refer to the official [CORE portal](http://portal.core.edu.au/conf-ranks/) for the most authoritative data.
 
+### DBLP SPARQL Integration
+
+The extension now retrieves publication metadata via the public
+[DBLP SPARQL endpoint](https://sparql.dblp.org/sparql). Using SPARQL avoids
+HTML scraping and allows flexible queries like filtering by venue or year.
+It also provides richer citation data for future features.
+
 ## Contributing & Bug Reports (BETA)
 
 This extension is currently in BETA. Your feedback is invaluable!

--- a/src/content.ts
+++ b/src/content.ts
@@ -106,8 +106,9 @@ let publicationTableObserver: MutationObserver | null = null;
 let rankMapForObserver: Map<string, string> | null = null; // Maps URL to Rank
 
 // --- START: DBLP Constants & Globals ---
-const DBLP_API_AUTHOR_SEARCH_URL = "https://dblp.org/search/author/api";
-const DBLP_API_PERSON_PUBS_URL_PREFIX = "https://dblp.org/pid/";
+// Use the public DBLP SPARQL endpoint instead of the legacy HTTP APIs
+// See: https://blog.dblp.org/2024/09/09/introducing-our-public-sparql-query-service/
+const DBLP_SPARQL_ENDPOINT = "https://sparql.dblp.org/sparql";
 const DBLP_HEURISTIC_MIN_OVERLAP_COUNT = 2;
 const DBLP_HEURISTIC_SCORE_THRESHOLD = 2.5;
 let dblpPubsForCurrentUser: DblpPublicationEntry[] = [];
@@ -1214,34 +1215,44 @@ function getScholarSamplePublications(count: number = 7): ScholarSamplePublicati
     return samples;
 }
 
+function escapeForSparql(str: string): string {
+    return str.replace(/['"\\]/g, match => '\\' + match);
+}
+
+async function executeSparqlQuery(query: string) {
+    const response = await fetch(DBLP_SPARQL_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/sparql-query',
+            'Accept': 'application/sparql-results+json'
+        },
+        body: query
+    });
+    if (!response.ok) throw new Error(`SPARQL query failed: ${response.status} ${response.statusText}`);
+    return await response.json();
+}
+
 async function searchDblpForAuthor(authorName: string, statusElement?: HTMLElement): Promise<DblpAuthorSearchResultHit[]> {
     const statusTextEl = statusElement?.querySelector('.gsr-status-text') as HTMLElement | null;
     if (statusTextEl) statusTextEl.textContent = `DBLP: Searching for "${authorName}"...`;
 
-    const url = new URL(DBLP_API_AUTHOR_SEARCH_URL);
-    url.searchParams.append('q', authorName);
-    url.searchParams.append('format', 'json');
-    url.searchParams.append('h', '10');
-    url.searchParams.append('c', '3'); // Request some completions (publications)
+    const escaped = escapeForSparql(authorName.toLowerCase());
+    const query = `PREFIX dblp:<https://dblp.org/rdf/schema#>\nPREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\nPREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nSELECT ?person ?name WHERE { ?person rdf:type dblp:Person . ?person rdfs:label ?name . FILTER(CONTAINS(LCASE(?name), '${escaped}')) } LIMIT 10`;
 
     try {
-        const response = await fetch(url.toString());
-        if (!response.ok) {
-            console.warn(`DBLP: Author search failed for "${authorName}": ${response.statusText}`);
-            if (statusTextEl) statusTextEl.textContent = `DBLP: Search failed (${response.status}).`;
-            return [];
+        const data = await executeSparqlQuery(query);
+        const hits: DblpAuthorSearchResultHit[] = (data.results?.bindings || []).map((b: any) => ({
+            info: { author: b.name.value, url: b.person.value }
+        }));
+        if (hits.length > 0 && statusTextEl) {
+            statusTextEl.textContent = `DBLP: Found ${hits.length} potential author(s). Analyzing...`;
         }
-        const data: DblpAuthorSearchResult = await response.json();
-        if (data.result?.hits?.hit) {
-            const hits = Array.isArray(data.result.hits.hit) ? data.result.hits.hit : [data.result.hits.hit];
-            if (statusTextEl) statusTextEl.textContent = `DBLP: Found ${hits.length} potential author(s). Analyzing...`;
-            return hits;
-        }
+        return hits;
     } catch (error) {
-        console.error("DBLP: Error during author search:", error);
+        console.error("DBLP: SPARQL author search error:", error);
+        if (statusTextEl) statusTextEl.textContent = `DBLP: Search failed`;
+        return [];
     }
-    if (statusTextEl) statusTextEl.textContent = `DBLP: No results or error for "${authorName}".`;
-    return [];
 }
 
 function extractPidFromDblpUrl(dblpAuthorUrl: string): string | null {
@@ -1394,89 +1405,47 @@ async function fetchPublicationsFromDblp(
     statusTextEl.textContent = `DBLP: Fetching publications for PID ${authorPidPath}…`;
   }
 
-  const xmlUrl = `${DBLP_API_PERSON_PUBS_URL_PREFIX}${authorPidPath}.xml`;
+  const query = `PREFIX dblp:<https://dblp.org/rdf/schema#>\nPREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\nSELECT ?publ ?title ?venue ?pages ?year ?stream WHERE { ?publ dblp:authoredBy <https://dblp.org/pid/${authorPidPath}> . ?publ dblp:title ?title . OPTIONAL{ ?publ dblp:publishedIn ?venueUri . ?venueUri rdfs:label ?venue } OPTIONAL{ ?publ dblp:pagination ?pages } OPTIONAL{ ?publ dblp:yearOfPublication ?year } OPTIONAL{ ?publ dblp:publishedInStream ?stream } }`;
   const publications: DblpPublicationEntry[] = [];
 
   try {
-    const response = await fetch(xmlUrl);
-    if (!response.ok) {
-      console.warn(
-        `DBLP: Fetching publications XML failed for PID "${authorPidPath}": ${response.statusText} (${response.status})`
-      );
-      if (statusTextEl) statusTextEl.textContent = "DBLP: XML fetch failed.";
-      return [];
-    }
+    const data = await executeSparqlQuery(query);
+    for (const b of data.results?.bindings || []) {
+      const dblpKey = b.publ.value.replace('https://dblp.org/rec/', '');
+      const title = b.title.value;
+      const year = b.year ? b.year.value : null;
+      const pages = b.pages ? b.pages.value : null;
+      const rawVenue = b.venue ? b.venue.value : null;
+      let acronym: string | null = null;
+      let venue_full: string | null = null;
 
-    const xmlText = await response.text();
-    const parser  = new DOMParser();
-    const xmlDoc  = parser.parseFromString(xmlText, "application/xml");
-
-    if (xmlDoc.querySelector("parsererror")) {
-      console.error("DBLP: XML parse error for PID", authorPidPath);
-      if (statusTextEl) statusTextEl.textContent = "DBLP: XML parse error.";
-      return [];
-    }
-
-    const items = Array.from(xmlDoc.querySelectorAll("dblpperson > r > *"));
-
-    for (const item of items) {
-      const dblpKey = item.getAttribute("key") || "";
-      if (!dblpKey) continue;                       // safety
-
-      const title = (item.querySelector("title")?.textContent || "")
-                      .replace(/\.$/, "");
-      if (!title) continue;
-
-      const year  = item.querySelector("year")?.textContent || null;
-      const pages = item.querySelector("pages")?.textContent || null;
-
-      /* ---------- 1. raw venue (booktitle / journal / …) ---------- */
-      const venueElements = ["booktitle", "journal", "series", "school"];
-      let rawVenue: string | null = null;
-      for (const tag of venueElements) {
-        const txt = item.querySelector(tag)?.textContent?.trim();
-        if (txt) { rawVenue = txt; break; }
-      }
-
-      /* ---------- 2. stream-derived metadata (optional) ---------- */
-      let acronym:     string | null = null;
-      let venue_full:  string | null = null;
-
-      const pubUrl = item.querySelector("url")?.textContent?.trim();
-      if (pubUrl) {
-        const streamMatch =
-          pubUrl.match(/^db\/conf\/[^/]+\/([a-zA-Z][\w-]*?)(\d{4}.*)?\.html/);
-        if (streamMatch?.[1]) {
-          const streamId     = streamMatch[1];
-          const streamXmlUrl = `https://dblp.org/streams/conf/${streamId}.xml`;
-          const streamMeta   = await fetchDblpStreamMetadata(streamXmlUrl);
-
-          if (streamMeta) {
-            acronym    = streamMeta.acronym ?? null;   // may still be null
-            venue_full = streamMeta.title    ?? null;
-          }
+      if (b.stream) {
+        const streamUri: string = b.stream.value;
+        const streamId = streamUri.substring(streamUri.lastIndexOf('/') + 1);
+        const streamXmlUrl = `https://dblp.org/streams/conf/${streamId}.xml`;
+        const streamMeta = await fetchDblpStreamMetadata(streamXmlUrl);
+        if (streamMeta) {
+          acronym = streamMeta.acronym ?? null;
+          venue_full = streamMeta.title ?? null;
         }
       }
 
-      /* ---------- 3. push entry ---------- */
       publications.push({
         dblpKey,
         title,
-        venue      : rawVenue,   // ← always “raw” venue
+        venue: rawVenue,
         year,
         pages,
-        venue_full,              // ← null if no valid stream
-        acronym                  // ← null if no valid stream
+        venue_full,
+        acronym,
       });
     }
 
     if (statusTextEl) {
-      statusTextEl.textContent =
-        `DBLP: Fetched ${publications.length} publications.`;
+      statusTextEl.textContent = `DBLP: Fetched ${publications.length} publications.`;
     }
-
   } catch (err) {
-    console.error("DBLP: Error fetching/parsing XML:", err);
+    console.error("DBLP: Error running SPARQL publications query:", err);
     if (statusTextEl) statusTextEl.textContent = "DBLP: Error fetching pubs.";
   }
 


### PR DESCRIPTION
## Summary
- fetch author and publication data via DBLP's public SPARQL service
- adjust code to parse SPARQL results
- document SPARQL usage in README

## Testing
- `npm run build`
- `PWTEST_MODE=ci npm run e2e` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68418987ff0c8329877b83f93605ff46