### PR TITLE
Update author sanitizer and tests

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1203,6 +1203,8 @@ function sanitizeAuthorName(name: string): string {
         /[,\s]+professor$/i,
     ];
     for (const p of patterns) cleaned = cleaned.replace(p, "");
+    cleaned = cleaned.replace(/\s*\([^)]*\)\s*/g, " ");
+    cleaned = cleaned.replace(/\s+/g, " ");
     return cleaned.trim();
 }
 


### PR DESCRIPTION
## Summary
- extend name sanitation logic to drop parenthetical phrases and excess spaces

## Testing
- `npm run build`
- `PWTEST_MODE=ci npm run e2e`
- `npm run clean`


------
https://chatgpt.com/codex/tasks/task_e_6841eaa66a548329b2a6d00929d70e42