### PR TITLE
Add caching and refresh button for self citation stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This lightweight Chrome extension looks up an author's DBLP profile and displays
 | Feature | Description |
 |---------|-------------|
 | 🔄 **Self-citation stats** | Shows the proportion of citations where the author cites themselves, using DBLP's SPARQL endpoint. |
+| 💾 **Caching** | Statistics are cached per author and can be refreshed using the provided button. |
 
 ## Quick Install
 


### PR DESCRIPTION
## Summary
- cache DBLP citation stats in localStorage
- add Refresh button to update cached stats
- document caching feature in README

## Testing
- `npm run build`
- `PWTEST_MODE=ci npm run e2e`
- `npm run clean`


------
https://chatgpt.com/codex/tasks/task_e_6846de90a8748329892f76c4017d948d