### PR TITLE
Add shared DBLP helper utilities

### DIFF
--- a/dist/background.js
+++ b/dist/background.js
@@ -8,62 +8,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-// Simple Jaro-Winkler implementation (no external deps)
-export function jaroWinkler(a, b) {
-    if (a === b)
-        return 1;
-    const maxDist = Math.floor(Math.max(a.length, b.length) / 2) - 1;
-    const matchA = [];
-    const matchB = [];
-    let matches = 0;
-    for (let i = 0; i < a.length; i++) {
-        const start = Math.max(0, i - maxDist);
-        const end = Math.min(i + maxDist + 1, b.length);
-        for (let j = start; j < end; j++) {
-            if (!matchB[j] && a[i] === b[j]) {
-                matchA[i] = matchB[j] = true;
-                matches++;
-                break;
-            }
-        }
-    }
-    if (!matches)
-        return 0;
-    let t = 0;
-    let k = 0;
-    for (let i = 0; i < a.length; i++) {
-        if (matchA[i]) {
-            while (!matchB[k])
-                k++;
-            if (a[i] !== b[k])
-                t++;
-            k++;
-        }
-    }
-    const m = matches;
-    const jaro = (m / a.length + m / b.length + (m - t / 2) / m) / 3;
-    let l = 0;
-    while (l < 4 && a[l] === b[l])
-        l++;
-    return jaro + l * 0.1 * (1 - jaro);
-}
+// Utility helpers shared with tests
+import { jaroWinkler, sanitizeAuthorName, getScholarSamplePublications, extractPidFromDblpUrl, } from "./src/utils";
 // --- Type Definitions ---
 // Note: These are now read globally by the TS compiler, no imports needed.
 // The official, recommended DBLP SPARQL endpoint
 const DBLP_SPARQL_ENDPOINT = "https://sparql.dblp.org/sparql";
-function sanitizeAuthorName(name) {
-    return name.toLowerCase().replace(/[^a-z0-9]/g, " ").replace(/\s+/g, " ").trim();
-}
-export function getScholarAuthorName(raw) {
-    return sanitizeAuthorName(raw.split("(")[0]);
-}
-export function getScholarSamplePublications(titles, limit = 5) {
-    return titles.slice(0, limit).map(t => sanitizeAuthorName(t));
-}
-export function extractPidFromDblpUrl(url) {
-    const m = url.match(/\/pid\/([^/]+\/[^/.]+)/);
-    return m ? m[1] : "";
-}
 export function searchDblpForAuthor(name) {
     return __awaiter(this, void 0, void 0, function* () {
         var _a, _b;

--- a/dist/src/dblpSelfCitation.js
+++ b/dist/src/dblpSelfCitation.js
@@ -1,0 +1,61 @@
+// src/dblpSelfCitation.ts
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+/**
+ * Helper utilities for querying DBLP self-citation statistics.
+ * The returned rate is between 0 and 1 (1 == all citations are self-citations).
+ */
+const DBLP_SPARQL_ENDPOINT = 'https://sparql.dblp.org/sparql';
+/** Execute a SPARQL query against DBLP and return the JSON result. */
+function executeSparqlQuery(query) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const url = `${DBLP_SPARQL_ENDPOINT}?query=${encodeURIComponent(query)}&output=json`;
+        const response = yield fetch(url, {
+            headers: { Accept: 'application/sparql-results+json' },
+        });
+        if (!response.ok) {
+            throw new Error(`HTTP error ${response.status}`);
+        }
+        return (yield response.json());
+    });
+}
+/**
+ * Fetch self-citation statistics for a DBLP profile.
+ * @param pid DBLP author PID such as `00/1`.
+ */
+export function fetchSelfCitationStats(pid) {
+    return __awaiter(this, void 0, void 0, function* () {
+        var _a, _b, _c, _d, _e, _f;
+        const authorUri = `https://dblp.org/pid/${pid}`;
+        const totalQuery = `
+    PREFIX dblp: <https://dblp.org/rdf/schema#>
+    SELECT (COUNT(DISTINCT ?citing_paper) AS ?total) WHERE {
+      BIND(<${authorUri}> AS ?author_uri)
+      ?authored_paper dblp:authoredBy ?author_uri .
+      ?citing_paper dblp:cites ?authored_paper .
+    }`;
+        const selfQuery = `
+    PREFIX dblp: <https://dblp.org/rdf/schema#>
+    SELECT (COUNT(DISTINCT ?citing_paper) AS ?self) WHERE {
+      BIND(<${authorUri}> AS ?author_uri)
+      ?authored_paper dblp:authoredBy ?author_uri .
+      ?citing_paper dblp:cites ?authored_paper .
+      ?citing_paper dblp:authoredBy ?author_uri .
+    }`;
+        const [totalResp, selfResp] = yield Promise.all([
+            executeSparqlQuery(totalQuery),
+            executeSparqlQuery(selfQuery),
+        ]);
+        const total = parseInt((_c = (_b = (_a = totalResp.results.bindings[0]) === null || _a === void 0 ? void 0 : _a.total) === null || _b === void 0 ? void 0 : _b.value) !== null && _c !== void 0 ? _c : '0', 10);
+        const self = parseInt((_f = (_e = (_d = selfResp.results.bindings[0]) === null || _d === void 0 ? void 0 : _d.self) === null || _e === void 0 ? void 0 : _e.value) !== null && _f !== void 0 ? _f : '0', 10);
+        const rate = total === 0 ? 0 : self / total;
+        return { total, self, rate };
+    });
+}

--- a/dist/src/utils.js
+++ b/dist/src/utils.js
@@ -1,0 +1,70 @@
+// src/utils.ts
+/**
+ * Normalise an author or publication string for fuzzy matching.
+ * Converts to lowercase, strips non-alphanumerics and collapses whitespace.
+ */
+export function sanitizeAuthorName(name) {
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+/**
+ * Compute the Jaro-Winkler similarity between two strings.
+ * Returns a score between 0 and 1 where 1 means exact match.
+ * Implementation is intentionally lightweight with no external dependencies.
+ */
+export function jaroWinkler(a, b) {
+    if (a === b)
+        return 1;
+    const maxDist = Math.floor(Math.max(a.length, b.length) / 2) - 1;
+    const matchA = [];
+    const matchB = [];
+    let matches = 0;
+    for (let i = 0; i < a.length; i++) {
+        const start = Math.max(0, i - maxDist);
+        const end = Math.min(i + maxDist + 1, b.length);
+        for (let j = start; j < end; j++) {
+            if (!matchB[j] && a[i] === b[j]) {
+                matchA[i] = matchB[j] = true;
+                matches++;
+                break;
+            }
+        }
+    }
+    if (!matches)
+        return 0;
+    let t = 0;
+    let k = 0;
+    for (let i = 0; i < a.length; i++) {
+        if (matchA[i]) {
+            while (!matchB[k])
+                k++;
+            if (a[i] !== b[k])
+                t++;
+            k++;
+        }
+    }
+    const m = matches;
+    const jaro = (m / a.length + m / b.length + (m - t / 2) / m) / 3;
+    let l = 0;
+    while (l < 4 && a[l] === b[l])
+        l++;
+    return jaro + l * 0.1 * (1 - jaro);
+}
+/** Extract the clean author name from Google Scholar profile text. */
+export function getScholarAuthorName(raw) {
+    return sanitizeAuthorName(raw.split("(")[0]);
+}
+/**
+ * Create a small sample of publication titles, normalised for comparison.
+ */
+export function getScholarSamplePublications(titles, limit = 5) {
+    return titles.slice(0, limit).map((t) => sanitizeAuthorName(t));
+}
+/** Extract a DBLP PID from a DBLP profile URL. */
+export function extractPidFromDblpUrl(url) {
+    const m = url.match(/\/pid\/([^/]+\/[^/.]+)/);
+    return m ? m[1] : "";
+}

--- a/src/dblpSelfCitation.ts
+++ b/src/dblpSelfCitation.ts
@@ -1,0 +1,66 @@
+// src/dblpSelfCitation.ts
+
+/**
+ * Helper utilities for querying DBLP self-citation statistics.
+ * The returned rate is between 0 and 1 (1 == all citations are self-citations).
+ */
+
+const DBLP_SPARQL_ENDPOINT = 'https://sparql.dblp.org/sparql';
+
+interface SparqlBinding {
+  [key: string]: { value: string; type: string };
+}
+interface SparqlResponse {
+  results: { bindings: SparqlBinding[] };
+}
+
+/** Execute a SPARQL query against DBLP and return the JSON result. */
+async function executeSparqlQuery(query: string): Promise<SparqlResponse> {
+  const url = `${DBLP_SPARQL_ENDPOINT}?query=${encodeURIComponent(query)}&output=json`;
+  const response = await fetch(url, {
+    headers: { Accept: 'application/sparql-results+json' },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error ${response.status}`);
+  }
+  return (await response.json()) as SparqlResponse;
+}
+
+export interface SelfCitationStats {
+  total: number;
+  self: number;
+  rate: number;
+}
+
+/**
+ * Fetch self-citation statistics for a DBLP profile.
+ * @param pid DBLP author PID such as `00/1`.
+ */
+export async function fetchSelfCitationStats(pid: string): Promise<SelfCitationStats> {
+  const authorUri = `https://dblp.org/pid/${pid}`;
+  const totalQuery = `
+    PREFIX dblp: <https://dblp.org/rdf/schema#>
+    SELECT (COUNT(DISTINCT ?citing_paper) AS ?total) WHERE {
+      BIND(<${authorUri}> AS ?author_uri)
+      ?authored_paper dblp:authoredBy ?author_uri .
+      ?citing_paper dblp:cites ?authored_paper .
+    }`;
+  const selfQuery = `
+    PREFIX dblp: <https://dblp.org/rdf/schema#>
+    SELECT (COUNT(DISTINCT ?citing_paper) AS ?self) WHERE {
+      BIND(<${authorUri}> AS ?author_uri)
+      ?authored_paper dblp:authoredBy ?author_uri .
+      ?citing_paper dblp:cites ?authored_paper .
+      ?citing_paper dblp:authoredBy ?author_uri .
+    }`;
+
+  const [totalResp, selfResp] = await Promise.all([
+    executeSparqlQuery(totalQuery),
+    executeSparqlQuery(selfQuery),
+  ]);
+
+  const total = parseInt(totalResp.results.bindings[0]?.total?.value ?? '0', 10);
+  const self = parseInt(selfResp.results.bindings[0]?.self?.value ?? '0', 10);
+  const rate = total === 0 ? 0 : self / total;
+  return { total, self, rate };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,75 @@
+// src/utils.ts
+
+/**
+ * Normalise an author or publication string for fuzzy matching.
+ * Converts to lowercase, strips non-alphanumerics and collapses whitespace.
+ */
+export function sanitizeAuthorName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Compute the Jaro-Winkler similarity between two strings.
+ * Returns a score between 0 and 1 where 1 means exact match.
+ * Implementation is intentionally lightweight with no external dependencies.
+ */
+export function jaroWinkler(a: string, b: string): number {
+  if (a === b) return 1;
+  const maxDist = Math.floor(Math.max(a.length, b.length) / 2) - 1;
+  const matchA: boolean[] = [];
+  const matchB: boolean[] = [];
+  let matches = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    const start = Math.max(0, i - maxDist);
+    const end = Math.min(i + maxDist + 1, b.length);
+    for (let j = start; j < end; j++) {
+      if (!matchB[j] && a[i] === b[j]) {
+        matchA[i] = matchB[j] = true;
+        matches++;
+        break;
+      }
+    }
+  }
+
+  if (!matches) return 0;
+  let t = 0;
+  let k = 0;
+  for (let i = 0; i < a.length; i++) {
+    if (matchA[i]) {
+      while (!matchB[k]) k++;
+      if (a[i] !== b[k]) t++;
+      k++;
+    }
+  }
+  const m = matches;
+  const jaro = (m / a.length + m / b.length + (m - t / 2) / m) / 3;
+  let l = 0;
+  while (l < 4 && a[l] === b[l]) l++;
+  return jaro + l * 0.1 * (1 - jaro);
+}
+
+/** Extract the clean author name from Google Scholar profile text. */
+export function getScholarAuthorName(raw: string): string {
+  return sanitizeAuthorName(raw.split("(")[0]);
+}
+
+/**
+ * Create a small sample of publication titles, normalised for comparison.
+ */
+export function getScholarSamplePublications(
+  titles: string[],
+  limit = 5
+): string[] {
+  return titles.slice(0, limit).map((t) => sanitizeAuthorName(t));
+}
+
+/** Extract a DBLP PID from a DBLP profile URL. */
+export function extractPidFromDblpUrl(url: string): string {
+  const m = url.match(/\/pid\/([^/]+\/[^/.]+)/);
+  return m ? m[1] : "";
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": [
-    "*.ts"                               
+    "*.ts",
+    "src/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- create a new `src/utils.ts` module with helper functions
- expose a `fetchSelfCitationStats` helper in `src/dblpSelfCitation.ts`
- consume utilities from background script
- compile new modules
- update TypeScript config to include `src` folder

## Testing
- `npm run build`
- `PWTEST_MODE=ci npm run e2e` *(fails: Missing script)*
- `npm run clean` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848576495b483298174a34e2ade17d4