### PR TITLE
Fix background script module type

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -128,8 +128,9 @@
     "https://sparql.dblp.org/*"
   ],
 
-"background": {
-    "service_worker": "dist/background.js"
+  "background": {
+    "service_worker": "dist/background.js",
+    "type": "module"
   },
 
   "icons": {


### PR DESCRIPTION
## Summary
- set Chrome extension background service worker to module type

## Testing
- `npm ci` *(fails: no package-lock)*
- `npx playwright install --with-deps` *(fails: playwright permission denied)*
- `npm run build`
- `PWTEST_MODE=ci npm run e2e` *(fails: missing script)*
- `npm run clean` *(fails: missing script)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684862a092108329878b7dbf5a19ab6e