### PR TITLE
Fix build output directory

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -65,7 +65,7 @@
         "https://scholar.google.ua/*",
         "https://scholar.google.us/*"
       ],
-      "js": ["dist/content.js"]
+      "js": ["build/content.js"]
     }
   ],
 
@@ -129,7 +129,7 @@
   ],
 
   "background": {
-    "service_worker": "dist/background.js",
+    "service_worker": "build/background.js",
     "type": "module"
   },
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es6",                     
     "module": "es6",                
-    "outDir": "./dist",                  
+    "outDir": "./build",
     "strict": true,                      
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- compile TypeScript into `./build`
- update manifest script paths

## Testing
- `npm run build`
- `npx playwright test` *(fails: `fetch failed`)*

------
https://chatgpt.com/codex/tasks/task_e_684865e3d5388329aa00b958b1721c4e